### PR TITLE
Handle pending valuations for funding events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # PMS
+
+A minimal portfolio management system demonstrating funding event handling
+and pending valuation reprocessing.

--- a/portfolio.py
+++ b/portfolio.py
@@ -1,0 +1,52 @@
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class FundingEvent:
+    ccy: str
+    amount: float
+    val: Optional[float] = None
+    status: str = "pending valuation"
+
+class Portfolio:
+    """A simple portfolio to track funding events and compute net flows/TWR."""
+    def __init__(self, prices: Optional[Dict[str, float]] = None):
+        self.prices: Dict[str, float] = prices or {}
+        self.pending: List[FundingEvent] = []
+        self.net_flows: float = 0.0
+        self.twr: float = 1.0
+
+    def add_funding_event(self, ccy: str, amount: float) -> FundingEvent:
+        price = self.prices.get(ccy)
+        if price is None:
+            event = FundingEvent(ccy=ccy, amount=amount)
+            self.pending.append(event)
+            logger.info("Pending valuation for %s", ccy)
+            return event
+        val = amount * price
+        event = FundingEvent(ccy=ccy, amount=amount, val=val, status="valued")
+        self._apply_event(event)
+        return event
+
+    def update_prices(self, new_prices: Dict[str, float]) -> None:
+        self.prices.update(new_prices)
+        remaining: List[FundingEvent] = []
+        for event in self.pending:
+            price = self.prices.get(event.ccy)
+            if price is None:
+                logger.warning("Unresolved asset for valuation: %s", event.ccy)
+                remaining.append(event)
+                continue
+            event.val = event.amount * price
+            event.status = "valued"
+            self._apply_event(event)
+        self.pending = remaining
+
+    def _apply_event(self, event: FundingEvent) -> None:
+        assert event.val is not None
+        self.net_flows += event.val
+        # Simplified TWR adjustment: treat event value as return factor
+        self.twr *= (1 + event.val)

--- a/test_portfolio.py
+++ b/test_portfolio.py
@@ -1,0 +1,31 @@
+import logging
+import pytest
+
+from portfolio import Portfolio
+
+
+def test_pending_event_when_price_missing(caplog):
+    p = Portfolio(prices={})
+    with caplog.at_level(logging.INFO):
+        evt = p.add_funding_event("BTC", 1)
+    assert evt.val is None
+    assert evt.status == "pending valuation"
+    assert evt in p.pending
+    assert "Pending valuation" in caplog.text
+
+
+def test_event_revaluated_when_price_available():
+    p = Portfolio(prices={})
+    p.add_funding_event("ETH", 2)
+    p.update_prices({"ETH": 10})
+    assert not p.pending
+    assert p.net_flows == pytest.approx(20)
+    assert p.twr != 1.0
+
+
+def test_unresolved_assets_logged(caplog):
+    p = Portfolio(prices={})
+    p.add_funding_event("XRP", 5)
+    with caplog.at_level(logging.WARNING):
+        p.update_prices({})
+    assert "Unresolved asset" in caplog.text


### PR DESCRIPTION
## Summary
- implement Portfolio class to track funding events and support pending valuation
- re-evaluate pending events as prices arrive and update net flows and TWR
- log unresolved assets and add unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b7d21dcea48323b6b84a0d2c4c71bd