### PR TITLE
Normalize timestamp precision in _ms

### DIFF
--- a/account_monitor.py
+++ b/account_monitor.py
@@ -305,12 +305,12 @@ def _ms(ts) -> Optional[int]:
     if ts is None:
         return None
     try:
-        return int(ts)
+        t = float(ts)
     except Exception:
-        try:
-            return int(float(ts) * 1000)
-        except Exception:
-            return None
+        return None
+    if abs(t) < 10 ** 12:
+        t *= 1000
+    return int(t)
 
 def _trust_nonfinal() -> bool:
     return os.environ.get("FLOW_TRUST_NONFINAL", "0").lower() in ("1","true","yes","on")

--- a/test_account_monitor_ms.py
+++ b/test_account_monitor_ms.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+# Stub external dependencies of account_monitor
+ccxt = types.ModuleType('ccxt')
+sys.modules.setdefault('ccxt', ccxt)
+
+dotenv = types.ModuleType('dotenv')
+dotenv.load_dotenv = lambda: None
+sys.modules.setdefault('dotenv', dotenv)
+
+requests = types.ModuleType('requests')
+requests.post = lambda *a, **k: types.SimpleNamespace(raise_for_status=lambda: None)
+sys.modules.setdefault('requests', requests)
+
+pytz = types.ModuleType('pytz')
+pytz.timezone = lambda name: types.SimpleNamespace()
+sys.modules.setdefault('pytz', pytz)
+
+matplotlib = types.ModuleType('matplotlib')
+matplotlib.use = lambda *a, **k: None
+sys.modules.setdefault('matplotlib', matplotlib)
+
+plt = types.ModuleType('matplotlib.pyplot')
+sys.modules.setdefault('matplotlib.pyplot', plt)
+
+pandas = types.ModuleType('pandas')
+pandas.DataFrame = type('DataFrame', (), {})
+sys.modules.setdefault('pandas', pandas)
+
+from account_monitor import _ms
+
+def test_ms_converts_seconds_to_ms():
+    assert _ms(1700000000) == 1700000000 * 1000
+
+
+def test_ms_accepts_milliseconds():
+    assert _ms(1700000000000) == 1700000000000


### PR DESCRIPTION
## Summary
- Normalize timestamps to milliseconds in `_ms`, converting second-resolution values (<1e12) to ms
- Add unit tests for second- and millisecond-resolution inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b7d78e5eac8323a952fa85305c111c