### PR TITLE
Prefer final status during funding event deduplication

### DIFF
--- a/account_monitor.py
+++ b/account_monitor.py
@@ -556,7 +556,7 @@ def fetch_funding_events_raw(ex, label: str, lookback_days: Optional[int] = None
         attempts.append({"method": f"{ex_id}_raw", "ok": False, "err": repr(e)})
 
     # combine and deduplicate before final status filtering
-    combined = deduplicate_events([ccxt_events, raw_events])
+    combined = deduplicate_events([ccxt_events, raw_events], ex_id)
 
     # keep only final (or all if FLOW_TRUST_NONFINAL=1)
     filtered: List[Dict[str, Any]] = []

--- a/event_deduplicator.py
+++ b/event_deduplicator.py
@@ -1,9 +1,37 @@
 import logging
-from typing import Iterable, List, Dict, Any, Hashable, Set
+from typing import Iterable, List, Dict, Any, Hashable, Optional, Dict as TDict
+
+from final_statuses import is_final as _is_final
 
 logger = logging.getLogger(__name__)
 
-def deduplicate_events(pages: Iterable[Iterable[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+def _event_is_final(exchange: Optional[str], event: Dict[str, Any]) -> bool:
+    """Return ``True`` if the event status is final for ``exchange``.
+
+    The helper is deliberately defensive: any missing fields or unsupported
+    values simply yield ``False`` rather than raising, mirroring the behaviour
+    of the production code where best effort is preferred over strict
+    validation.
+    """
+
+    if not exchange:
+        return False
+
+    kind = str(event.get("type") or "").lower()
+    if kind == "withdrawal":
+        kind = "withdraw"
+    status = event.get("status")
+    if kind not in ("deposit", "withdraw") or status is None:
+        return False
+    try:
+        return _is_final(exchange, kind, status)
+    except Exception:  # pragma: no cover - safety guard
+        return False
+
+
+def deduplicate_events(
+    pages: Iterable[Iterable[Dict[str, Any]]], exchange: Optional[str] = None
+) -> List[Dict[str, Any]]:
     """Deduplicate events collected from multiple pages.
 
     Parameters:
@@ -14,6 +42,11 @@ def deduplicate_events(pages: Iterable[Iterable[Dict[str, Any]]]) -> List[Dict[s
         unique ID if present (e.g., 'uid', 'id', or 'exchange_id'). If no unique
         ID exists, a composite key of ('txId', 'currency', 'timestamp') is used.
 
+        When duplicates share the same key, preference is given to the record
+        whose status is considered *final* according to
+        :func:`final_statuses.is_final`. This allows pending ccxt events to be
+        replaced by later raw events that have reached a terminal state.
+
     Debug logs include the number of pages, total events processed, and the
     count after deduplication.
     """
@@ -22,7 +55,7 @@ def deduplicate_events(pages: Iterable[Iterable[Dict[str, Any]]]) -> List[Dict[s
     total_events = sum(len(page) for page in pages_list)
     logger.debug("Fetched %d pages containing %d events", total_pages, total_events)
 
-    seen: Set[Hashable] = set()
+    seen: TDict[Hashable, int] = {}
     unique_events: List[Dict[str, Any]] = []
 
     for page in pages_list:
@@ -37,9 +70,17 @@ def deduplicate_events(pages: Iterable[Iterable[Dict[str, Any]]]) -> List[Dict[s
                 event.get("currency"),
                 event.get("timestamp"),
             )
-            if key not in seen:
-                seen.add(key)
+
+            idx = seen.get(key)
+            if idx is None:
+                seen[key] = len(unique_events)
                 unique_events.append(event)
+            else:
+                existing = unique_events[idx]
+                if _event_is_final(exchange, event) and not _event_is_final(
+                    exchange, existing
+                ):
+                    unique_events[idx] = event
 
     logger.debug("Deduplicated events count: %d", len(unique_events))
     return unique_events

--- a/test_funding_events.py
+++ b/test_funding_events.py
@@ -23,7 +23,7 @@ sys.modules.setdefault("pandas", pandas_stub)
 import account_monitor as am
 
 
-def test_raw_attempt_and_dedup(monkeypatch):
+def test_pending_ccxt_event_replaced_by_final_raw(monkeypatch):
     class DummyEx:
         id = "binance"
 
@@ -73,7 +73,10 @@ def test_raw_attempt_and_dedup(monkeypatch):
     events = am.fetch_funding_events_raw(ex, "LBL", lookback_days=1)
 
     assert called["raw"] is True
-    assert events == []
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["id"] == "1"
+    assert ev["status"] == "success"
 
     attempt_line = next(l for l in logs if l.startswith("FUNDING attempts FULL:"))
     attempts = json.loads(attempt_line.split(":", 1)[1].strip())


### PR DESCRIPTION
## Summary
- Replace duplicate funding events with the final-status record when available
- Pass exchange id to deduplicator
- Test that raw final events override pending ccxt entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b7dabf08bc8323a5f61a535ca66dec