### PR TITLE
Avoid pandas groupby warning in history export

### DIFF
--- a/account_monitor.py
+++ b/account_monitor.py
@@ -793,7 +793,10 @@ def export_excel_snapshot(now_ny: datetime,
                 g["cumulative_return_pct"] = (1.0 + g["daily_return_pct"].fillna(0.0)).cumprod() - 1.0
                 g["rolling_pnl_usd"] = g["daily_return_usd"].fillna(0.0).cumsum()
                 return g
-            df_hist = df_hist.groupby("account", group_keys=False).apply(_add_cum_rolling)
+            df_hist = (
+                df_hist.groupby("account", group_keys=False)
+                       .apply(_add_cum_rolling, include_groups=False)
+            )
         frames["History"] = _sanitize_df_for_excel(df_hist)
 
     with pd.ExcelWriter(path, engine="openpyxl") as writer:

--- a/test_account_monitor_ms.py
+++ b/test_account_monitor_ms.py
@@ -96,7 +96,7 @@ class DataFrame:
             def __init__(self, df, key):
                 self.df = df
                 self.key = key
-            def apply(self, func):
+            def apply(self, func, include_groups=False):
                 groups = {}
                 for row in self.df.data:
                     groups.setdefault(row[self.key], []).append(row)


### PR DESCRIPTION
## Summary
- Prevent pandas `groupby().apply` from including group rows by default in Excel history export.
- Update pandas stub in tests to accept the new `include_groups` argument.

## Testing
- `pytest -q`
- `python - <<'PY'
import sys, json, os
from datetime import datetime
import test_account_monitor_ms  # sets up stubs and modules
from account_monitor import export_excel_snapshot

os.environ['EXCEL_DIR'] = '/tmp'
now = datetime(2024,1,2,15,0)
accounts={'acct': {'value':100,'start_value':100,'net_flows':0,'twr_factor':1.0}}
path = export_excel_snapshot(now, accounts, {}, {}, {}, 'USD')
print('path', path)
with open(path) as f:
    sheets=json.load(f)
print('history', sheets['History'])
PY`
- ⚠️ `pip install pandas openpyxl` (HTTP 403)


------
https://chatgpt.com/codex/tasks/task_b_68b7ddf3828c8323962990f65dc626ff