### PR TITLE
Log skipped non-final funding events

### DIFF
--- a/account_monitor.py
+++ b/account_monitor.py
@@ -565,6 +565,11 @@ def fetch_funding_events_raw(ex, label: str, lookback_days: Optional[int] = None
         st = ev.get("status")
         if _is_final(ex_id, kind, st):
             filtered.append(ev)
+        else:
+            ev_id = ev.get("id")
+            _trace_flow(label, [
+                f"FUNDING skipped non-final event label={label} id={ev_id} status={st}"
+            ])
 
     out = sorted(filtered, key=lambda r: r.get("timestamp", 0))
 

--- a/test_funding_events.py
+++ b/test_funding_events.py
@@ -87,6 +87,45 @@ def test_pending_ccxt_event_replaced_by_final_raw(monkeypatch):
     assert "binance_raw" in methods
 
 
+def test_non_final_event_logged_and_skipped(monkeypatch):
+    class DummyEx:
+        id = "binance"
+
+        def fetch_deposits(self, since=None):
+            return [
+                {
+                    "id": "1",
+                    "timestamp": since + 1000,
+                    "currency": "BTC",
+                    "amount": 1,
+                    "status": "pending",
+                }
+            ]
+
+        def fetch_withdrawals(self, since=None):
+            return []
+
+    ex = DummyEx()
+
+    # no raw events available
+    monkeypatch.setattr(am, "_binance_raw", lambda ex, s, u: ([], []))
+
+    logs = []
+
+    def fake_trace(label, lines):
+        logs.extend(lines)
+
+    monkeypatch.setattr(am, "_trace_flow", fake_trace)
+
+    events = am.fetch_funding_events_raw(ex, "LBL", lookback_days=1)
+
+    assert events == []
+
+    skipped = [l for l in logs if "skipped non-final" in l]
+    assert skipped, "skip log missing"
+    assert any("id=1" in l and "label=LBL" in l for l in skipped)
+
+
 def test_missing_price_flows_reflected_in_excel(monkeypatch, tmp_path):
     events = [
         {"id": "1", "type": "deposit", "currency": "ABC", "amount": 10},


### PR DESCRIPTION
## Summary
- Trace non-final funding events skipped during fetch, noting exchange label and event ID
- Test skip logging for pending funding events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68b7decc46d4832383dc9174785133bb